### PR TITLE
Added --recursive, otherwise you get an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ You can find this site at https://www.openbikesensor.org/
 Make sure to clone the repository with the `--recursive` flag, or if you forgot that, initialize submodules like this:
 
 ```bash
-git submodule update --init
+git submodule update --init --recursive
 ```
 
 To build the site for development, install [hugo](https://gohugo.io/) and then run:


### PR DESCRIPTION
Added --recursive, otherwise you get an error when building with hugo:
Error: Error building site: TOCSS: failed to transform "scss/main.scss" (text/x-scss): SCSS processing failed: file "stdin", line 6, col 1: File to import not found or unreadable: ../vendor/bootstrap/scss/bootstrap.