### PR TITLE
setting the default language to de

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,7 +13,7 @@ enableGitInfo = true
 
 # Language settings
 contentDir = "content/en"
-defaultContentLanguage = "en"
+defaultContentLanguage = "de"
 defaultContentLanguageInSubdir = false
 # Useful when translating.
 enableMissingTranslationPlaceholders = true


### PR DESCRIPTION
Hey Paul,

due to the fact, that our current community is mostly German speaking, I suggest to switch the default language to German – instead of English. Especially because in the mobile version the language selector is not available (yet).

Hope this works well (first attempt to contribute).

Best regards,
Franziska