### PR TITLE
Add page aliases for important pages

### DIFF
--- a/content/docs/hardware/v00.03/build-instructions/index.de.md
+++ b/content/docs/hardware/v00.03/build-instructions/index.de.md
@@ -1,6 +1,8 @@
 ---
 title: Bauanleitung v00.03
 linkTitle: Bauanleitung
+aliases:
+- /bauanleitung
 ---
 
 {{% alert title="Achtung" color="danger" %}}

--- a/content/docs/user-guide/mounting/index.de.md
+++ b/content/docs/user-guide/mounting/index.de.md
@@ -2,6 +2,8 @@
 linkTitle: Montage
 title: Montage des Sensors am Fahrrad
 weight: 15
+aliases:
+- /montage
 ---
 
 {{% alert title="Hinweis" color="info" %}}

--- a/content/docs/user-guide/quickstart.de.md
+++ b/content/docs/user-guide/quickstart.de.md
@@ -2,6 +2,8 @@
 title: Schnellstart-Anleitung
 linkTitle: Schnellstart
 weight: 10
+aliases:
+- /start
 ---
 
 > Diese Anleitung geht davon aus, dass du einen funktionierenden OpenBikeSensor


### PR DESCRIPTION
* https://openbikesensor.org/bauanleitung
* https://openbikesensor.org/montage
* https://openbikesensor.org/start

For the German build instructions, mounting instructions, and quickstart
guide, respectively.