### PR TITLE
Dependency versions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.80.0'
+          hugo-version: '0.85.0'
           extended: true
 
       - name: Setup Node

--- a/README.md
+++ b/README.md
@@ -36,3 +36,26 @@ Install [hugo](https://gohugo.io/) (extended version!) and then run:
 ```bash
 hugo server -D
 ```
+
+### Dependency versions
+
+We try to keep up to date with hugo and docsy. The current docsy version is
+referenced in the submodule, so we're not sticking to any releases there. The
+current hugo version is specified in the [github flow
+file](.github/workflows/gh-pages.yml).
+
+Since hugo does not introduce many breaking changes, it should be fine to work
+with other versions locally. If you run into trouble, try to install the exact
+version referenced in the github flow file, as that is used to build this site
+for production. Always make sure to install hugo's *extended version*.
+
+As for Node.js, we currently use version 12 for installing the dependencies
+(postcss etc., see above). However, any newer version that is supported on your
+operating system should work just as well, since we're not really using node
+itself, just the package manager (npm).
+
+If you want to update any of these components, feel free to do so and change
+the places where it is referenced in the github flow or submodule, as well as
+this documentation. It makes sense to stay up to date, but isn't really
+required for a site of this size and scope. When updating, please create a
+separate pull request to change the canonical version(s) in this repository.


### PR DESCRIPTION
* Add a big note on how to update and where to find the canonical versions
* Update hugo to [0.85.0](https://gohugo.io/news/0.85.0-relnotes/)