### PR TITLE
fix: add spacing to icons in buttons on start page

### DIFF
--- a/content/_index.de.html
+++ b/content/_index.de.html
@@ -17,15 +17,15 @@ resources:
 	<p class="mb-5">Wir stehen für Open Innovation, Open Source, Open Data & Open Science.</p>
 
 	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="#einleitung">
-		<i class="fas fa-arrow-down"></i> Mehr erfahren
+		<i class="fas fa-arrow-down mr-2"></i> Mehr erfahren
 	</a>
 
 	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://twitter.com/openbikesensor" target="_blank" rel="noopener noreferrer nofollow">
-		<i class="fab fa-twitter ml-2 "></i> @OpenBikeSensor
+		<i class="fab fa-twitter mr-2"></i> @OpenBikeSensor
 	</a>
 
 	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="#unterstuetzen" rel="noopener noreferrer nofollow">
-		<i class="fas fa-hand-holding-heart"></i> Unterstützen
+		<i class="fas fa-hand-holding-heart mr-2"></i> Unterstützen
 	</a>
 
 </div>


### PR DESCRIPTION
- add some right margin to icons inside the buttons on the start page

before:
<img width="765" alt="Screenshot 2021-08-07 at 14 31 24" src="https://user-images.githubusercontent.com/4677417/128600242-b339da0c-4ce5-4ee8-838b-bc2a97f89ce6.png">

after:
<img width="799" alt="Screenshot 2021-08-07 at 14 31 54" src="https://user-images.githubusercontent.com/4677417/128600246-159f5007-1f6c-4d1b-b9d0-cf90f8cea178.png">

