### PR TITLE
Document new https password dialogue before login

### DIFF
--- a/content/docs/user-guide/configuration/minimal/index.de.md
+++ b/content/docs/user-guide/configuration/minimal/index.de.md
@@ -34,7 +34,7 @@ Nur in einem WLAN mit Internet funktioniert der Upload der Daten, der auch direk
 Seit der Version 0.6 wird eine https Verbindung angeboten und der Zugang zum Webinterface durch eine Pin gesichert.
 
 * Um das Konfigurationsmenü zu öffnen kann **go to https** klicken
-  * (Seit Version 0.6.00) Bei der Verwendung von HTTPS ist eine Zertifikatswarnung zu erwarten, die abgenitckt werden kann oder die man durch Import des Zertifikats in den Browser zum Schweigen gebracht bringen kann. Das Zertifikat wird im Dialog zum Download angeboten.
+  * (Seit Version 0.6.00) Bei der Verwendung von HTTPS ist eine Zertifikatswarnung zu erwarten, die abgenickt werden kann oder die man durch Import des Zertifikats in den Browser zum Schweigen gebracht bringen kann. Das Zertifikat wird im Dialog zum Download angeboten.
   * (Seit Version 0.7.00) Statt **go to https** kann die Warnung durch **enable unencrypted access** umgangen werden. Dies sollte nur in sicheren Drahtlosnetzen verwendet werden (eigenes Heimnetz oder Openbikesensor als access point).
 
 * Nach Auswahl des Konfigurationsmodus wird im Browser ein Nutzername und ein Passwort verlangt.

--- a/content/docs/user-guide/configuration/minimal/index.de.md
+++ b/content/docs/user-guide/configuration/minimal/index.de.md
@@ -30,6 +30,17 @@ Wenn ein konfiguriertes WLAN in Reichweite ist, verbindet sich der OpenBikeSenso
 
 Nur in einem WLAN mit Internet funktioniert der Upload der Daten, der auch direkt vom OpenBikeSensor ausgelöst werden kann durch Drücken und Festhalten des Knopfes
 
+## Login in das Konfiguraitionsmenü OBS
+Seit der Version 0.6 wird eine https Verbindung angeboten und der Zugang zum Webinterface durch eine Pin gesichert.
+
+* Um das Konfigurationsmenü zu öffnen kann **go to https** klicken
+  * (Seit Version 0.6.00) Bei der Verwendung von HTTPS ist eine Zertifikatswarnung zu erwarten, die abgenitckt werden kann oder die man durch Import des Zertifikats in den Browser zum Schweigen gebracht bringen kann. Das Zertifikat wird im Dialog zum Download angeboten.
+  * (Seit Version 0.7.00) Statt **go to https** kann die Warnung durch **enable unencrypted access** umgangen werden. Dies sollte nur in sicheren Drahtlosnetzen verwendet werden (eigenes Heimnetz oder Openbikesensor als access point).
+
+* Nach Auswahl des Konfigurationsmodus wird im Browser ein Nutzername und ein Passwort verlangt.
+  * **Benutzer:**: `obs` (anmerkung: der Benutzername wird nicht überprüft und die einzige Bedingung ist dass die Zeichenfolge nicht leer gelassen wird)
+  * **Passwort:** wird im Display des OBS angezeigt.
+
 ## Wichtige Einstellungen im Konfigurationsmenü
 
 ### General


### PR DESCRIPTION
the current firmware requires a username and password. Document how it works. (the part about password being nonempty string was validated on an obs and cross-checked with the firmware code)