### PR TITLE
Change most reference to slack to point to the forum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tech-doc-hugo
 # From jekyll, so that nobody accidentally commits old files
 _site
 .bundle
+.hugo_build.lock

--- a/content/_index.de.html
+++ b/content/_index.de.html
@@ -13,19 +13,23 @@ resources:
 {{< blocks/cover title="OpenBikeSensor" image_anchor="top" height="400" >}}
 <div class="mx-auto">
 
-	<h1>Überholabstandsmessung für Radfahrende.</h1>
-	<p class="mb-5">Wir stehen für Open Innovation, Open Source, Open Data & Open Science.</p>
+	<h2 class="mb-3">Überholabstandsmessung für Radfahrende</h2>
+	<p class="mb-5">Open Innovation, Open Source, Open Data, Open Science</p>
 
-	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="#einleitung">
-		<i class="fas fa-arrow-down mr-2"></i> Mehr erfahren
+	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://forum.openbikesensor.org" target="_blank" rel="noopener noreferrer nofollow">
+		<i class="fab fa-discourse mr-1"></i> Forum
 	</a>
 
-	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://twitter.com/openbikesensor" target="_blank" rel="noopener noreferrer nofollow">
-		<i class="fab fa-twitter mr-2"></i> @OpenBikeSensor
+	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="{{< relref "/docs" >}}">
+    <i class="fas fa-book-open mr-1"></i> Dokumentation
+	</a>
+
+	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/openbikesensor" target="_blank" rel="noopener noreferrer nofollow">
+		<i class="fab fa-github mr-1"></i> Github
 	</a>
 
 	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="#unterstuetzen" rel="noopener noreferrer nofollow">
-		<i class="fas fa-hand-holding-heart mr-2"></i> Unterstützen
+		<i class="fas fa-hand-holding-heart mr-1"></i> Unterstützen
 	</a>
 
 </div>
@@ -33,17 +37,27 @@ resources:
 
 {{% blocks/section color="primary" %}}
 
-{{% blocks/feature icon="fab fa-slack" title="Mitreden & Mitentscheiden" url="/slack" url_text="Slack beitreten" %}}
-Komm in unseren offenen Slack. Tausche Dich aus. Stelle Fragen. Finde Leute aus Deiner Region. Hier koordinieren wir uns, stimmen uns ab und treffen gemeinschaftlich Entscheidungen.
+<div class="container">
+<div class="row" style="padding: 0">
+{{% blocks/feature icon="fab fa-discourse" title="Fragen und Diskutieren" url="https://forum.openbikesensor.org" url_text="Zum Forum" %}}
+Komm in unser Discourse-Forum, und diskutiere mit den anderen Interessierten
+und Aktiven. Hier findet fast alles einen Platz: Unterstützung bei Problemen,
+Lokalgruppen, Forschungs&shy;projekte, Events, Entwicklungsthemen, und vieles mehr.
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fas fa-biking" title="Bauen & Daten sammeln" url="/docs/hardware/v00.03.12/build-instructions/" url_text="Zur Bauanleitung" %}}
-Bau Dir Deinen eigenen Überholabstandsmesser. Wir unterstützen Dich dabei. Am besten schließt Du Dich einer der Sammelbestellungen und einem unserer Regio-Teams an.
+{{% blocks/feature icon="fas fa-biking" title="Bauen & Daten sammeln" url="/bauanleitung" url_text="Zur Bauanleitung" %}}
+Bau Dir Deinen eigenen Überholabstandsmesser. Wir unterstützen Dich dabei. Am
+besten schließt Du Dich einer der Sammelbestellungen und einem unserer
+Regio-Teams an.
 {{% /blocks/feature %}}
 
 {{% blocks/feature icon="fab fa-github" title="Weiterentwickeln" url="https://github.com/openbikesensor" url_text="Zu den GitHub-Repositories" %}}
-Was wir erstellen ist quelloffen, auf GitHub veröffentlichen wir den kompletten Code. Hier findest Du auch alle Pläne und Anleitungen sowie die Software zur Visualisierung der gesammelten Daten.
+Was wir erstellen ist quelloffen, auf GitHub veröffentlichen wir den kompletten
+Code. Hier findest Du auch alle Pläne und Anleitungen sowie die Software zur
+Visualisierung der gesammelten Daten.
 {{% /blocks/feature %}}
+</div>
+</div>
 
 {{% /blocks/section %}}
 
@@ -79,7 +93,7 @@ Uns geht es jedoch nicht nur um die Technik. Ergänzend entwickeln wir gemeinsam
 
 Es wäre toll, wenn schon bald viele mitmachen, und wir so zusammen Bewegung in die Sache bringen.
 
-Klingt interessant? Schau vorbei in unserem <a href="{{< relref "/slack" >}}">Slack Workspace</a>.
+Klingt interessant? <a href="{{< relref "/community" >}}">Hier kannst du Teil der Community werden.</a>
 
 </div>
 {{% /blocks/section %}}
@@ -101,7 +115,7 @@ Ein anderes Beispiel zeigt einen einzelnen Überholvorgang, von dem auch eine Vi
 
 {{< yt id=izUD16ffs_Q thumbnail="/thumbnails/izUD16ffs_Q.jpg" >}}
 
-Wer noch Ideen zur Visualisierung, Automatisierung, Programmierung, Auswertung, etc. hat oder einfach am Projekt interessiert ist und mitgestalten will, ist herzlich in der Community via <a href="{{< relref "/slack" >}}">Slack</a> eingeladen.
+Wer noch Ideen zur Visualisierung, Automatisierung, Programmierung, Auswertung, etc. hat oder einfach am Projekt interessiert ist und mitgestalten will, ist herzlich <a href="{{< relref "/community" >}}">in der Community</a> eingeladen.
 
 </div>
 {{% /blocks/section %}}

--- a/content/_index.de.html
+++ b/content/_index.de.html
@@ -115,7 +115,7 @@ Ein anderes Beispiel zeigt einen einzelnen Überholvorgang, von dem auch eine Vi
 
 {{< yt id=izUD16ffs_Q thumbnail="/thumbnails/izUD16ffs_Q.jpg" >}}
 
-Wer noch Ideen zur Visualisierung, Automatisierung, Programmierung, Auswertung, etc. hat oder einfach am Projekt interessiert ist und mitgestalten will, ist herzlich <a href="{{< relref "/community" >}}">in der Community</a> eingeladen.
+Wer noch Ideen zur Visualisierung, Automatisierung, Programmierung, Auswertung, etc. hat oder einfach am Projekt interessiert ist und mitgestalten will, ist herzlich <a href="{{< relref "/community" >}}">in die Community</a> eingeladen.
 
 </div>
 {{% /blocks/section %}}

--- a/content/_index.en.html
+++ b/content/_index.en.html
@@ -39,13 +39,13 @@ on topics like: help and support, local groups, projects, events and further dev
 {{% /blocks/feature %}}
 
 {{% blocks/feature icon="fas fa-biking" title="Build & measure" url="/bauanleitung" url_text="Zur Bauanleitung" %}}
-Build your own sensoric device. We will support you as much as we can. How
-about joining a local group of builders and bikers, and join a collective order
-to save on parts?
+Build your own device. We will support you as much as we can. How about joining
+a local group of builders and cyclists, and join a collective order to save on
+parts?
 {{% /blocks/feature %}}
 
 {{% blocks/feature icon="fab fa-github" title="Develop" url="https://github.com/openbikesensor" url_text="Zu den GitHub-Repositories" %}}
-Whatever we create, we make open source. Everything is available on GitHub,
+We publish everything we create as open source. Everything is available on GitHub,
 including the software code, schematics, blueprints, CAD models, instructions
 and documentation.
 {{% /blocks/feature %}}

--- a/content/_index.en.html
+++ b/content/_index.en.html
@@ -8,19 +8,51 @@ menu:
 
 {{< blocks/cover title="OpenBikeSensor" image_anchor="top" height="400" >}}
 <div class="mx-auto">
-	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/openbikesensor">
-		Github <i class="fab fa-github ml-2 "></i>
+	<h2 class="mb-3">Passing distance measurement for cyclists</h2>
+	<p class="mb-5">Open Innovation, Open Source, Open Data, Open Science</p>
+
+	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://forum.openbikesensor.org" target="_blank" rel="noopener noreferrer nofollow">
+		<i class="fab fa-discourse mr-1"></i> Forum
 	</a>
-  <a class="btn btn-lg btn-secondary mr-3 mb-4" href="{{< relref "/slack" >}}">
-		Slack<i class="fab fa-slack ml-2 "></i>
+
+	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="{{< relref "/docs" >}}">
+    <i class="fas fa-book-open mr-1"></i> Documentation
 	</a>
-	<a class="btn btn-lg btn-primary mr-3 mb-4" href="{{< relref "/docs" >}}">
-		Documentation <i class="fas fa-arrow-alt-circle-right ml-2"></i>
+
+	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/openbikesensor" target="_blank" rel="noopener noreferrer nofollow">
+		<i class="fab fa-github mr-1"></i> Github
 	</a>
-	<p class="lead mt-5">Passing distance measurement for cyclists. Open source, open data, open science.</p>
+
+	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="#unterstuetzen" rel="noopener noreferrer nofollow">
+		<i class="fas fa-hand-holding-heart mr-1"></i> Support
+	</a>
 </div>
 {{< /blocks/cover >}}
 
+{{% blocks/section color="primary" %}}
+
+<div class="container">
+<div class="row" style="padding: 0">
+{{% blocks/feature icon="fab fa-discourse" title="Ask and discuss" url="https://forum.openbikesensor.org" url_text="Zum Forum" %}}
+Come over to our Discourse forum for discussions with other interested and active community members
+on topics like: help and support, local groups, projects, events and further developments.
+{{% /blocks/feature %}}
+
+{{% blocks/feature icon="fas fa-biking" title="Build & measure" url="/bauanleitung" url_text="Zur Bauanleitung" %}}
+Build your own sensoric device. We will support you as much as we can. How
+about joining a local group of builders and bikers, and join a collective order
+to save on parts?
+{{% /blocks/feature %}}
+
+{{% blocks/feature icon="fab fa-github" title="Develop" url="https://github.com/openbikesensor" url_text="Zu den GitHub-Repositories" %}}
+Whatever we create, we make open source. Everything is available on GitHub,
+including the software code, schematics, blueprints, CAD models, instructions
+and documentation.
+{{% /blocks/feature %}}
+</div>
+</div>
+
+{{% /blocks/section %}}
 
 {{% blocks/section color="secondary" %}}
 <div class="container">
@@ -33,9 +65,7 @@ there is plans and information available publicly to build your own. Have a
 look at <a href="https://github.com/openbikesensor">Github</a>, where there are
 repositories for the firmware, PCBs, the files for 3D printing the case, the
 software for the frontend and backend of the data portal, and this
-documentation page. You're invited to join and help develop the sensor.
-
-The community mostly communicates through the open <a href="{{< relref "/slack" >}}">Slack</a>.
+documentation page. <a href="{{< relref "/community" >}}">You're invited to join</a> and help develop the sensor.
 
 In our data portal, users can upload data recorded with their OpenBikeSensors and
 optionally share them as Open Data with the public.
@@ -76,8 +106,8 @@ exposed to in this very moment.
 
 If you have ideas for visualisation, automation, software and tool development
 and analysis of the data available from the recorded tracks, or you're just
-interested in joining the project or keeping up to date with it, please join
-the community in the open slack.
+interested in joining the project or keeping up to date with it, please
+<a href="{{< relref "/community" >}}">join the community</a>.
 
 </div>
 {{% /blocks/section %}}

--- a/content/blog/2021-11-12-forum/index.de.md
+++ b/content/blog/2021-11-12-forum/index.de.md
@@ -1,0 +1,38 @@
+---
+title: "Startschuss für neues OpenBikeSensor-Forum"
+linkTitle: Neues Forum
+date: '2021-11-12'
+---
+
+Wir haben vor Kurzem unser eigenes Forum gestartet, und nun heißt es offiziell:
+Herzlich willkommen im OpenBikeSensor Discourse:
+
+https://forum.openbikesensor.org
+
+Da wir uns aus verschiedenen Gründen von Slack verabschieden müssen und wollen,
+waren wir lange auf der Suche nach etwas neuem. Wir hoffen, dass das Forum für
+einen Großteil der Kommunikation zwischen Mitgliedern der Community der
+richtige Platz ist. Vorteile sind vor allem:
+
+* Das Forum kann öffentlich gelesen werden. So sind bekannte Probleme und deren
+  Lösungen auffindbar, Entscheidungen transparent nachvollziehbar, und die
+  Einstiegshürde zum Projekt generell geringer.
+* Die Kommunikation verläuft automatisch in Threads. Neue und aktive Themen
+  landen ganz oben, es ist leichter die Diskussionen zu verfolgen. Starke
+  Moderationstools erlauben das "Aufräumen" und Aufbereiten von Informationen,
+  sodass Gesagtes langfristig hilfreich bleibt.
+* Wir haben datenschutztechnisch die Kontrolle und müssen keinem US-Konzern
+  unsere Daten anvertrauen.
+* Discourse, die Forumssoftware, ist Open Source. Es werden nicht plötzlich
+  hohe Kosten auf uns zukommen, wenn das Projekt "zu groß" geworden ist.
+
+Was uns nun noch fehlt, ist eine Möglichkeit zur schnellen und unkomplizierten
+"Ad-Hoc Kommunikation", also ein Chat für kurzlebige Informationen oder
+Koordinierung, sowie 1:1-Gespräche. Wir werden hier vermutlich eine Lösung mit
+[Matrix](https://matrix.org/) anstreben, aber die genaue Umsetzung fehlt noch.
+
+Vorerst bleibt der Slack wo er ist, aber wenn das Forum für die passenden
+Themen gut angenommen wird, werden wir hoffentlich bald einige Channel
+archivieren können.
+
+Wir sehen uns im Forum!

--- a/content/community/_index.de.md
+++ b/content/community/_index.de.md
@@ -3,12 +3,15 @@ title: Community
 menu:
   main:
     weight: 40
+aliases:
+- /kontakt
+- /contact
 ---
 
 <section class="row td-box td-box--1 position-relative td-box--gradient td-box--height-auto">
 <div class="container text-center td-arrow-down">
 <span class="h4 mb-0">
-  
+
 # Werde Teil der OpenBikeSensor-Community
 
 Der OpenBikeSensor ist ein offenes Projekt an dem alle teilnehmen können. Hilf
@@ -21,17 +24,22 @@ auszuwerten. So kannst du mitmachen:
 
 {{% blocks/section color="dark" %}}
 
-{{% blocks/feature icon="fab fa-slack" title="Mitreden" url="/slack" url_text="Beitreten" %}}
-Komm in unseren Slack, und chatte mit den anderen Teilnehmenden. Hier koordinieren wir fast alles. Unterstützung, Ideen, Events...
+{{% blocks/feature icon="fab fa-discourse" title="Fragen und Diskutieren" url="https://forum.openbikesensor.org" url_text="Zum Forum" %}}
+Komm in unser Discourse-Forum, und diskutiere mit den anderen Interessierten
+und Aktiven. Hier findet fast alles einen Platz: Unterstützung bei Problemen,
+Lokalgruppen, Forschungs&shy;projekte, Events, Entwicklungsthemen, und vieles mehr.
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fab fa-github" title="Mitmachen" url="https://github.com/openbikesensor" url_text="Code" %}}
-Schau auch mal bei unseren Github-Repositories vorbei. Dort ist der ganze Code,
-alle Pläne und Anleitungen zu finden.
+{{% blocks/feature icon="fab fa-github" title="Weiterentwickeln" url="https://github.com/openbikesensor" url_text="Zu den GitHub-Repositories" %}}
+Was wir erstellen ist quelloffen, auf GitHub veröffentlichen wir den kompletten
+Code. Hier findest Du auch alle Pläne und Anleitungen sowie die Software zur
+Visualisierung der gesammelten Daten.
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fab fa-twitter" title="Mitbekommen" url="https://twitter.com/openbikesensor" url_text="Folgen" %}}
-Wir halten euch auf dem Laufenden bei Twitter. Jetzt folgen und nichts verpassen!
+{{% blocks/feature icon="fab fa-slack" title="Koordinieren" url="/slack" url_text="Zum Slack" %}}
+Noch verwenden wir Slack, um uns direkt auszutauschen zu Themen, die nicht
+ins Forum passen. Dort werden Termine angekündigt und geplant, Kurzfristiges
+koordiniert, und Sammelbestellungen abgewickelt.
 {{% /blocks/feature %}}
 
 {{% /blocks/section %}}

--- a/content/community/_index.en.md
+++ b/content/community/_index.en.md
@@ -3,12 +3,15 @@ title: Community
 menu:
   main:
     weight: 40
+aliases:
+- /kontakt
+- /contact
 ---
 
 <section class="row td-box td-box--1 position-relative td-box--gradient td-box--height-auto">
 <div class="container text-center td-arrow-down">
 <span class="h4 mb-0">
-  
+
 # Join the OpenBikeSensor community
 
 The OpenBikeSensor is an open project that everbody can join. You too can help
@@ -20,16 +23,21 @@ with development of the sensor, testing, collecting data and analysing it. Here 
 
 {{% blocks/section color="dark" %}}
 
-{{% blocks/feature icon="fab fa-slack" title="Communicate" url="/en/slack" url_text="Join"%}}
-Feel free to join the Slack, and have a chat about the project. We coordinate everything here: Support, Ideas, Events...
+{{% blocks/feature icon="fab fa-discourse" title="Ask and discuss" url="https://forum.openbikesensor.org" url_text="Visit the forum" %}}
+Come over to our Discourse forum for discussions with other interested and active community members
+on topics like: help and support, local groups, projects, events and further developments.
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fab fa-github" title="Contribute" url="https://github.com/openbikesensor" url_text="Show" %}}
-Check out our repositories on Github. You'll find all code, plans and instructions there.
+{{% blocks/feature icon="fab fa-github" title="Develop" url="https://github.com/openbikesensor" url_text="Show repositories" %}}
+Whatever we create, we make open source. Everything is available on GitHub,
+including the software code, schematics, blueprints, CAD models, instructions
+and documentation.
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fab fa-twitter" title="Follow" url="https://twitter.com/openbikesensor" url_text="Follow" %}}
-We'll post news and latest developments on Twitter, so the world knows!
+{{% blocks/feature icon="fab fa-slack" title="Coordinate" url="/slack" url_text="Join Slack" %}}
+We are still using Slack for direct communications that do not fit the format
+of the forum.  This is where we organize meetings, coordinate events, chat with
+each other, and organize collective orders.
 {{% /blocks/feature %}}
 
 {{% /blocks/section %}}

--- a/content/community/_index.en.md
+++ b/content/community/_index.en.md
@@ -29,7 +29,7 @@ on topics like: help and support, local groups, projects, events and further dev
 {{% /blocks/feature %}}
 
 {{% blocks/feature icon="fab fa-github" title="Develop" url="https://github.com/openbikesensor" url_text="Show repositories" %}}
-Whatever we create, we make open source. Everything is available on GitHub,
+We publish everything we create as open source. Everything is available on GitHub,
 including the software code, schematics, blueprints, CAD models, instructions
 and documentation.
 {{% /blocks/feature %}}

--- a/content/docs/hardware/_index.de.md
+++ b/content/docs/hardware/_index.de.md
@@ -24,8 +24,9 @@ Regeln durch Bestellung bei einem Hersteller anhand der Designdateien passiert.
 
 **Hinweis:** Diese Website ist noch (und auf absehbare Zeit) in Arbeit, einige
 Teile könnten unvollständig sein oder komplett fehlen. Auch Fehler sind nie
-auszuschließen.  Wenn du Schwierigkeiten hast, frag auf jeden Fall im Slack
-nach. Erwarte nicht, dass alles auf Anhieb klappt, aber es gibt genug Leute die
+auszuschließen.  Wenn du Schwierigkeiten hast,
+[frag auf jeden Fall nach Hilfe]({{< relref "/community" >}}).
+Erwarte nicht, dass alles auf Anhieb klappt, aber es gibt genug Leute die
 dir gern weiterhelfen, und ihr Wissen teilen. Aber du brauchst auch keine Angst
 zu haben, loszulegen -- selbst wenn nicht immer offensichtlich ist, wie alles
 funktioniert, so ist es trotzdem auch für Anfänger:innen möglich, erfolgreich
@@ -38,7 +39,7 @@ sind Sammelbestellungen eine gute Möglichkeit die Komplexität aufzuteilen und
 für jede:n Einzelne:n zu verringern. Dabei sparen wir alle Geld, denn in Menge
 bestellt sind viele Teile günstiger. Wenn du dich mit einer Lokalgruppe oder
 überregional vernetzen möchtest, um so einn Sammelbestellung durchzuführen oder
-daran teilzunehmen, komm in unseren Slack!
+daran teilzunehmen, komm in unsere [Community]({{< relref "/community" >}})!
 
 {{< imgproc construction-kit Resize 600x >}}
 OpenBikeSensor 00.03.10 Bausatz

--- a/content/docs/hardware/_index.en.md
+++ b/content/docs/hardware/_index.en.md
@@ -20,7 +20,8 @@ from your favorite manufacturer, and for assembly of the sensor from all the
 parts.
 
 **Note:** This website is still work-in-progress, and some parts of the
-documentation are not complete. If you run into trouble, ask in Slack. Don't
+documentation are not complete. If you run into trouble, ask in the
+[Community]({{< relref "/community" >}}). Don't
 expect a smooth experience just yet -- but we're working on it. However, don't
 fear, while not necessarily straightforward at all times, it is still very much
 possible for beginners to complete this build and construct their own OBS.
@@ -28,8 +29,10 @@ possible for beginners to complete this build and construct their own OBS.
 ## Construction kits
 
 Because the OpenBikeSensor consists many parts from many different sources,
-bulk orders organized by local groups are advisable. Head over to Slack if you
-want to organize or paricipate in a bulk order.
+bulk orders organized by local groups are advisable. Head over to
+[Community]({{< relref "/community" >}}) if you want to organize or paricipate
+in a bulk order.
+
 
 {{< imgproc construction-kit Resize 600x >}}
 OpenBikeSensor Construction Kit featuring Vertical Case and PCB 00.03.10

--- a/content/docs/hardware/general/collective-order/_index.de.md
+++ b/content/docs/hardware/general/collective-order/_index.de.md
@@ -8,7 +8,7 @@ weight: 10
 Diese Dokumentationsseite beschreibt Hinweise für Menschen, die eine
 Sammelbestellung _organisieren_. Wenn du an der Organisation aktueller
 Sammelbestellungen interessiert bist, und zum Beispiel einen Bausatz auf diese
-Weise erhalten möchtest, besuch den Kanal `#obs_hw_bauteil-börse` im Slack.
+Weise erhalten möchtest, [schau doch in der Community vorbei]({{< relref "/community" >}}).
 {{% /alert %}}
 
 

--- a/content/docs/hardware/general/pcb/_index.de.md
+++ b/content/docs/hardware/general/pcb/_index.de.md
@@ -12,8 +12,9 @@ Optionen:
 * Das PCB anhand der Designdateien von einem Platinenhersteller anfertigen
   lassen. Je nachdem wo, in welcher Qualität und wie viele Platinen du
   bestellst wird dies erstaunlich wenig bis sehr viel kosten.
-* Finde heraus, ob jemensch anders schon Platinen anhand der gleichen Dateien hat herstellen lassen. Eventuell hat er:sie noch
-  Exemplare übrig, frag am besten im [Slack]({{< ref "slack" >}}) nach dafür.
+* Finde heraus, ob jemensch anders schon Platinen anhand der gleichen Dateien
+  hat herstellen lassen. Eventuell hat er:sie noch Exemplare übrig, frag am
+  besten [in der Community]({{< ref "/community" >}}) nach.
 * Bastel dir selbst eine Platine, ganz im DIY-Stil. Da unseren Platinen jedoch
   Durchkontaktierungen und beidseitige Leiterbahnen benötigen, ist das
   besonders schwierig. Je nach Ausrüstung und Erfahrung ist es aber machbar.

--- a/content/docs/hardware/general/pcb/_index.en.md
+++ b/content/docs/hardware/general/pcb/_index.en.md
@@ -15,7 +15,7 @@ manufactured piece of equipment that's hard to build yourself. Here are your opt
   on *where*, at *which quality* and *how many boards* you order, this will
   cost a little to a lot of money.
 * Find somebody who has ordered your selected PCB already and still has
-  duplicates in stock. Ask in Slack for this.
+  duplicates in stock. Ask around [in the community]({{< relref "/community" >}}).
 * Build the PCB in a DIY fashion. Since the PCB uses vias and through-hole
   components, this is going to be hard, but if you're properly equipped and
   have done this before, or are not afraid of repeated failure, this might be

--- a/content/docs/hardware/v00.02/build-instructions/index.de.md
+++ b/content/docs/hardware/v00.02/build-instructions/index.de.md
@@ -34,8 +34,8 @@ aber gerade wenn du Anfänger bist könnte dies wichtig sein.
     Alles was wir dir mit den Bauteillisten, Schaltungsentwürfen und
     Anleitungen zeigen sind Vorschläge und können Fehler enthalten. Bist
     du dir an einer Stelle nicht sicher oder du glaubst hier könnte ein
-    Fehler vorhanden sein, dann melde dich in unserem
-    [Slack]({{< relref "/slack" >}}). Außerdem sind wir nicht für
+    Fehler vorhanden sein, dann melde dich in der
+    [Community]({{< relref "/community" >}}). Außerdem sind wir nicht für
     Fehler verantwortlich die du während des Aufbaus machst. Sollte
     etwas schief gehen und du brauchst Hilfe kannst du dich natürlich
     auch bei uns melden.
@@ -82,8 +82,8 @@ es sich anbieten das entsprechende Kapitel zu überfliegen und dir so
 über die möglichen Optionen klar zu werden. Bilder erklären manchmal
 einfach besser als eine Tabelle es kann.
 
-Du findest Fehler oder hast Fragen? Dann melde dich entweder in unserem
-[Slack]({{< relref "/slack" >}}) oder hinterlasse einen [Issue auf
+Du findest Fehler oder hast Fragen? Dann melde dich entweder in unserer
+[Community]({{< relref "/community" >}}) oder hinterlasse einen [Issue auf
 Github](https://github.com/openbikesensor/openbikesensor.github.io/issues/new).
 
 ## Vorbereitung

--- a/content/docs/hardware/v00.03.12/build-instructions/_index.de.md
+++ b/content/docs/hardware/v00.03.12/build-instructions/_index.de.md
@@ -18,7 +18,7 @@ funktionierenden Modell zu kommen. Wenn du alternative Wege gehen möchtest,
 kannst du das natürlich tun. Solltest du einen massentauglichen besseren oder
 einfacheren Weg für einen der Schritte finden, freuen wir uns über
 [Änderungsvorschläge](https://github.com/openbikesensor/openbikesensor.github.io/pulls),
-oder eine kurze Nachricht im Slack.
+oder eine kurze [Nachricht]({{< relref "/community" >}}).
 
 {{< imgproc "v00.03.12/19_Assembly/DSC08101.JPG" Fit "800x600" >}}
 Ein fertig gebauter OpenBikeSensor der Version v00.03.12

--- a/content/docs/user-guide/simra/index.de.md
+++ b/content/docs/user-guide/simra/index.de.md
@@ -17,7 +17,7 @@ Prinzipiell gibt es 3 Features, von denen wir nur 2 unterstützen können:
 
 Wir haben uns dazu entschieden, Bluetooth *vorläufig* auszubauen, da es das am
 wenigsten genutzte Feature ist. Hast du Interesse an einer anderen Kombination,
-melde dich bitte im Slack (#obs_sw_firmware) oder auf Github. 
+melde dich bitte auf Github.
 
 Alternativ gibt es auch die Möglichkeit, das Prozessormoduls durch eines mit
 mehr Speicher auszutauschen. Wenn du dir ein Gerät mit mehr Speicher gebaut
@@ -54,19 +54,19 @@ Bluetooth muss natürlich auf dem Smartphone aktiviert sein.
 ### Android
 
 1. App starten.
-2. In die Einstellungen gehen und unten OpenBikeSensor aktivieren: 
+2. In die Einstellungen gehen und unten OpenBikeSensor aktivieren:
 
     {{< imgproc enable_obs None />}}
-  
+
 3. OpenBikeSensor Einstellungen öffnen. Verfügbare Geräte werden gesucht.
 
     {{< imgproc found None />}}
 
-4. Auf den Eintrag mit "OpenBikeSensor xxx" drücken und anschließend auf "Verbinden" drücken. 
-  
+4. Auf den Eintrag mit "OpenBikeSensor xxx" drücken und anschließend auf "Verbinden" drücken.
+
     {{< imgproc connecting None />}}
 5. Der jeweils gemessene Wert sollte jetzt angezeigt werden.
-  
+
     {{< imgproc connected None />}}
 
 6. Jetzt muss man noch einstellen, wie breit der Lenker des Fahrrad (von der

--- a/content/faq/_index.de.md
+++ b/content/faq/_index.de.md
@@ -9,8 +9,8 @@ menu:
 
 Hier sammeln wir Fragen und Antworten, die uns häufig erreichen. Wenn dich
 etwas rund um das Projekt interessiert, schau doch mal ob deine Frage schon
-beantwortet ist. Ansonsten freuen wir uns natürlich jederzeit, wenn du über
-[Slack]({{< ref "/slack" >}}) zu uns Kontakt aufnimmst.
+beantwortet ist. Ansonsten freuen wir uns natürlich jederzeit, wenn du
+[zu uns Kontakt]({{< ref "/community" >}}) aufnimmst.
 
 Die Fragen in diesem Bereich sind nach Themengebiet sortiert. Wir sortieren
 nicht in Unterseiten, das heißt mit der Suchfunktion deines Browsers (Strg+F)

--- a/content/faq/build/i-am-a-beginner-can-i-build-one.de.md
+++ b/content/faq/build/i-am-a-beginner-can-i-build-one.de.md
@@ -10,7 +10,7 @@ genügend Zeit sollten es alle hinbekommen, ganz egal ob groß oder klein, jung
 oder alt. Natürlich muss gelötet, gebastelt und gecrimpt werden, und auch
 einige Schritte mit dem Computer sind nötig.  Das meiste haben wir detailliert
 beschrieben, und wenn du irgendwo stecken bleibst, kannst du immer im
-[Slack]({{< ref "/slack" >}}) nach Hilfe fragen.
+[Slack]({{< ref "/contact" >}}) nach Hilfe fragen.
 
 Wenn du dir noch nicht ganz zutraust, das ganze Gerät allein zu basteln, such
 dir doch Hilfe. In den meisten Regionen gibt es Maker-Spaces, Hackspaces,

--- a/content/faq/build/i-am-a-beginner-can-i-build-one.de.md
+++ b/content/faq/build/i-am-a-beginner-can-i-build-one.de.md
@@ -9,8 +9,8 @@ Ja. Natürlich hilft es, so etwas schon einmal gemacht zu haben. Aber mit
 genügend Zeit sollten es alle hinbekommen, ganz egal ob groß oder klein, jung
 oder alt. Natürlich muss gelötet, gebastelt und gecrimpt werden, und auch
 einige Schritte mit dem Computer sind nötig.  Das meiste haben wir detailliert
-beschrieben, und wenn du irgendwo stecken bleibst, kannst du immer im
-[Slack]({{< ref "/contact" >}}) nach Hilfe fragen.
+beschrieben, und wenn du irgendwo stecken bleibst, kannst du immer
+[nach Hilfe fragen]({{< ref "/contact" >}}).
 
 Wenn du dir noch nicht ganz zutraust, das ganze Gerät allein zu basteln, such
 dir doch Hilfe. In den meisten Regionen gibt es Maker-Spaces, Hackspaces,

--- a/content/faq/build/i-am-a-beginner-can-i-build-one.de.md
+++ b/content/faq/build/i-am-a-beginner-can-i-build-one.de.md
@@ -9,8 +9,8 @@ Ja. Natürlich hilft es, so etwas schon einmal gemacht zu haben. Aber mit
 genügend Zeit sollten es alle hinbekommen, ganz egal ob groß oder klein, jung
 oder alt. Natürlich muss gelötet, gebastelt und gecrimpt werden, und auch
 einige Schritte mit dem Computer sind nötig.  Das meiste haben wir detailliert
-beschrieben, und wenn du irgendwo stecken bleibst, kannst du immer
-[nach Hilfe fragen]({{< ref "/community" >}}).
+beschrieben, und wenn du irgendwo stecken bleibst, kannst du immer in der
+[Community]({{< ref "/community" >}}) nach Hilfe fragen.
 
 Wenn du dir noch nicht ganz zutraust, das ganze Gerät allein zu basteln, such
 dir doch Hilfe. In den meisten Regionen gibt es Maker-Spaces, Hackspaces,

--- a/content/faq/build/i-am-a-beginner-can-i-build-one.de.md
+++ b/content/faq/build/i-am-a-beginner-can-i-build-one.de.md
@@ -10,7 +10,7 @@ genügend Zeit sollten es alle hinbekommen, ganz egal ob groß oder klein, jung
 oder alt. Natürlich muss gelötet, gebastelt und gecrimpt werden, und auch
 einige Schritte mit dem Computer sind nötig.  Das meiste haben wir detailliert
 beschrieben, und wenn du irgendwo stecken bleibst, kannst du immer
-[nach Hilfe fragen]({{< ref "/contact" >}}).
+[nach Hilfe fragen]({{< ref "/community" >}}).
 
 Wenn du dir noch nicht ganz zutraust, das ganze Gerät allein zu basteln, such
 dir doch Hilfe. In den meisten Regionen gibt es Maker-Spaces, Hackspaces,

--- a/content/faq/build/where-do-i-get-a-sensor.de.md
+++ b/content/faq/build/where-do-i-get-a-sensor.de.md
@@ -9,9 +9,10 @@ nicht. Die Pläne sind frei im Internet verfügbar, sodass jede:r es selbst
 nachbauen kann. Kapazitäten zum (kommerziellen) Angebot fertiger Geräte haben
 wir aber keine.
 
-Über den Slack organisiert die Community regelmäßig Sammelbestellungen, sodass
-nicht jede:r alle Einzelteile bestellen muss. Das macht es günstiger und
-bequemer, einen Bausatz zu erhalten. Zusammenbauen musst du den dann aber selbst.
+Über den Slack organisiert [die Community]({{< ref "/community" >}}) regelmäßig
+Sammelbestellungen, sodass nicht jede:r alle Einzelteile bestellen muss. Das
+macht es günstiger und bequemer, einen Bausatz zu erhalten. Zusammenbauen musst
+du den dann aber selbst.
 
 Wenn du dich an einer Sammelbestellung beteiligen möchtest, oder dir sogar
 vorstellen könntest eine zu organisieren (eine [Bauteileliste]({{< ref

--- a/content/slack.de.md
+++ b/content/slack.de.md
@@ -9,15 +9,24 @@ title: Slack
 
 # Slack
 
-Die Community kommuniziert zum Großteil im offenen Slack. Alle sind eingeladen, beizutreten. Dort könnt ihr
+Wir versuchen, langsam aber sicher unsere Abhängigkeit von Slack zu lösen, und
+stattdessen in andere Kommunikationskanäle umzuziehen.
 
-* um Hilfe fragen beim Nachbau,
-* euch informieren über aktuelle Aktionen,
-* erfahren wie ihr bei der Entwicklung mithelfen könnt,
-* Sammelbestellungen organisieren,
-* ...und vieles mehr!
+Dennoch, einige Themen klären wir vorerst weiterhin in Slack:
+
+* kurzfristige Koordinierung
+* Terminankündigungen
+* Community-Themen
+* Sammelbestellungen
+* einige Lokalgruppen
+
+Falls du andere Themen, wie die technische Weiterentwicklung,
+Forschungsprojekte, Hilfe und Support und vieles weiteres disktuieren oder
+erfragen möchtest, schau doch stattdessen zunächst im [Forum]({{< relref
+"/community" >}}) vorbei.
 
 [Klick hier, um Slack beizutreten](https://openbikesensor.slack.com/join/shared_invite/zt-bxxr3taf-bD1UZqSmgFIy63qAm0MQXw)
+
 
 </div>
 {{% /blocks/section %}}

--- a/content/slack.en.md
+++ b/content/slack.en.md
@@ -9,13 +9,19 @@ title: Slack
 
 # Slack
 
-Our community connects mainly through our open slack workspace. Everybody is invited to join, so you can
+We are trying to move away from Slack and towards free and open communication channels.
 
-* ask for help when building your own OBS
-* get updates on current events
-* participate in the development of the OBS and everything around it,
-* organise collective part orders for bulk discounts,
-* ...and much more! 
+However, some topics still require the nature of Slack and have their place there for now, such as:
+
+* short-term coordination
+* event announcements
+* community topics
+* organizing of  collective orders
+* some local groups
+
+For topics like technical development, research projects, help and support and
+much more, there is now a good place in the new [Discourse forum]({{< relref
+"/community" >}}). Have a look there first ;)
 
 [Click here to join Slack](https://openbikesensor.slack.com/join/shared_invite/zt-bxxr3taf-bD1UZqSmgFIy63qAm0MQXw)
 

--- a/layouts/partials/parts-notes.md
+++ b/layouts/partials/parts-notes.md
@@ -53,9 +53,9 @@ geliefert werden und einige Wochen Lieferzeit haben, solltest du alles doppelt
   Die Community pflegt aktiv ein bestimmtes Gehäuse für jede PCB-Version.
   Schau' dich im
   [Gehäuse-Repository](https://github.com/openbikesensor/OpenBikeSensor3dPrintableCase)
-  auf Github um. Du kannst dein Gehäuse selbst drucken, im Slack andere darum
-  bitten, oder fertige Drucke anhand der Designdateien von einem
-  3D-Druck-Service bestellen (das ist aber in der Regel relativ teuer).
+  auf Github um. Du kannst dein Gehäuse selbst drucken, andere Mitglieder der
+  Community darum bitten, oder fertige Drucke anhand der Designdateien von
+  einem 3D-Druck-Service bestellen (das ist aber in der Regel relativ teuer).
 
 * **PCB**: Du benötigst ein PCB der passenden Version, speziell [anhand der
   Designdateien hergestellt]({{ ref . "/docs/hardware/general/pcb" }}). Dies sollte am besten


### PR DESCRIPTION
Also updates the community pages, the slack entrypage, the landing page, adds `/contact` and `/kontakt` aliases to the community page, and changes lots of wording for referencing to the community and ways to contact it.