### PR TITLE
fix: font in sidebar

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -280,7 +280,6 @@ pre {
 
 .td-sidebar-nav {
   padding: 1rem;
-  font-family: "Open Sans";
 
   ul {
     list-style: none;


### PR DESCRIPTION
Currently, only the sidebar uses "Open Sans" (which is not included on the server – so if you don't have it, it will fallback to a default font). To make the look more consistent, I've removed this single "Open Sans" instance. If we want to change the font, it should happen for the whole page, and the font should be available on the server, too.