### PR TITLE
Add a section for local groups to represent themselves

### DIFF
--- a/content/groups/_index.de.md
+++ b/content/groups/_index.de.md
@@ -1,0 +1,19 @@
+---
+title: Markers
+layout: groups
+type: page
+outputs:
+- json
+- html
+---
+
+# Wo wir zu finden sind.
+
+Hier siehst du Lokalgruppen, Initiativen und Einzelpersonen, die mitmachen!
+
+<div style="height: 400px; background: #EEE; display: flex; align-items: center; justify-content: center;">
+  Karte wird hier eingebettet
+</div>
+
+## Liste
+

--- a/content/groups/freiburg.de.md
+++ b/content/groups/freiburg.de.md
@@ -1,0 +1,21 @@
+---
+title: Lokalgruppe Freiburg
+type: groups
+marker_type: local_group
+geometry:
+  type: Point
+  coordinates: [7.84937, 47.99576]
+---
+
+## Über uns
+
+Bei uns sind viele Aktive, die sich um die technische
+Weiterentwicklung des Sensors in der Community kümmern.
+
+## Veranstaltungen
+
+Ab Frühjahr 2022 möchten wir monatlich im Strandcafe das "OpenBikeSensor
+Repair Cafe" durchführen, in dem wir zusammenkommen und uns gegenseitig beim Aufbau,
+Betrieb und der Reparatur von OpenBikeSensoren helfen. Auch Neulinge sind
+willkommen, um sich das ganze Anzuschauen und Mitstreiter:innen für neue Bestell-
+und Bau-Runden zu finden.

--- a/layouts/_default/groups.html.html
+++ b/layouts/_default/groups.html.html
@@ -1,0 +1,16 @@
+{{ define "main" }}
+<div style="height: 120px;"></div>
+<div class="container content mb-5">
+{{ with .Content }}
+{{ . }}
+{{ end }}
+
+<ul>
+{{ range .Pages }}
+  <li><a href="{{ .Permalink }}">{{.Title}}</a></li>
+{{ end }}
+</ul>
+
+</div>
+</div>
+{{ end }}

--- a/layouts/_default/groups.json.json
+++ b/layouts/_default/groups.json.json
@@ -1,0 +1,15 @@
+{{- $.Scratch.Add "index" slice -}}
+{{- range .Pages -}}
+{{- $.Scratch.Add "index" (
+    dict
+      "properties" (dict
+        "uri" .Permalink
+        "title" .Title
+        "description" .Plain
+        "html" .Content
+        "type" .Params.type
+      )
+      "geometry" .Params.geometry
+      ) -}}
+{{- end -}}
+{{- (dict "type" "FeatureCollection" "features" ($.Scratch.Get "index")) | jsonify -}}

--- a/layouts/groups/single.html.html
+++ b/layouts/groups/single.html.html
@@ -1,0 +1,13 @@
+{{ define "main" }}
+<div style="height: 120px;"></div>
+<div class="container content mb-5">
+
+<h1>{{ .Title }}</h1>
+{{ with .Content }}
+{{ . }}
+{{ end }}
+
+</div>
+</div>
+{{ end }}
+


### PR DESCRIPTION
Status: Draft/WIP/Proposition

This also exports information about each group to a big GeoJSON file at `/groups/index.json`, such that we can build a map from it (externally).
