### PR TITLE
Caution printers

### DIFF
--- a/content/docs/hardware/_index.de.md
+++ b/content/docs/hardware/_index.de.md
@@ -22,6 +22,19 @@ gibt es im [entsprechenden Abschnitt]({{< relref "general/case" >}}). Außerdem
 musst du eine [Platine erwerben]({{< relref "general/pcb" >}}), was in der
 Regeln durch Bestellung bei einem Hersteller anhand der Designdateien passiert.
 
+Wenn du mehrere OpenBikeSensoren herstellen möchtest, empfiehlt es sich, **bevor**
+du eine große Anzahl Gehäuse druckst ein Gerät komplett zusammen zu bauen. In
+der Vergangenheit kam es immer wieder dazu, dass sich Maße von Teilen geändert
+haben - z.b. lieferten Lieferanten plötzlich größere Displays. Wenn du einen 
+OpenBikeSensor mit den Teilen, die dir geliefert wurden, ins Gehäuse verbauen 
+konntest, kannst du relative sicher sein, dass du nicht später mit 10 Gehäusen 
+da stehst, in die die GPS-Antenne aus deiner Bestellung knapp nicht rein passt.
+
+Wenn du auf diese Weise bemerkst, dass Lieferanten plötzlich andere Teile
+liefern, [sprich es auf jeden Fall in der Community an]({{< relref "/community" >}}).
+Vielleicht muss die Lieferantenliste angepasst werden, oder es gibt eine
+einfache Änderung am Gehäuse, um auch mit den neuen Teilen kompatibel zu werden.
+
 **Hinweis:** Diese Website ist noch (und auf absehbare Zeit) in Arbeit, einige
 Teile könnten unvollständig sein oder komplett fehlen. Auch Fehler sind nie
 auszuschließen.  Wenn du Schwierigkeiten hast,

--- a/content/docs/hardware/_index.en.md
+++ b/content/docs/hardware/_index.en.md
@@ -10,6 +10,13 @@ are able to build your own OBS.
 Starting out, make sure to check out the [model selection]({{< relref "general/models" >}}) to figure
 out which version of the OBS you want to build.
 
+If you plan to build multiple OBS it is recommended to first print and fully assemble
+one version. In the past sometimes suppliers have slightly changed dimensions
+of parts they deliver. If you notice that before you print a bunch of cases it
+can still be fixed in the model. In that case mention it in the 
+[Community]({{< relref "/community" >}}. This allows us to adapt supplier
+lists or the case as needed.
+
 Next up, you will need to figure out all the parts that you need to purchase or
 create for your selected model. This includes a lot of electronic components, a
 PCB, the 3D printed case and fixtures, wires and fasteners. Check out the

--- a/content/docs/hardware/general/case/printing/_index.de.md
+++ b/content/docs/hardware/general/case/printing/_index.de.md
@@ -189,6 +189,7 @@ Die Teile zum Drucken:
 * [`MainCase/UsbCover.stl`](https://github.com/openbikesensor/OpenBikeSensor3dPrintableCase/blob/main/export/MainCase/UsbCover.stl)
 * [`MainCase/GpsAntennaLid.stl`](https://github.com/openbikesensor/OpenBikeSensor3dPrintableCase/blob/main/export/MainCase/GpsAntennaLid.stl)
 * [`Mounting/StandardMountAdapter.stl`](https://github.com/openbikesensor/OpenBikeSensor3dPrintableCase/blob/main/export/Mounting/StandardMountAdapter.stl)
+* [`Mounting/AttachmentCover.stl`](https://github.com/openbikesensor/OpenBikeSensor3dPrintableCase/blob/main/export/Mounting/AttachmentCover.stl)
 
 Die ersten zwei Teile gibt es jeweils auch mit OpenBikeSensor-Logo. Für jedes
 Bauteil sind hierfür vier Dateien verfügbar. Das Logo kann *invertiert* oder
@@ -200,6 +201,10 @@ OBS-Logo](https://github.com/openbikesensor/OpenBikeSensor3dPrintableCase/tree/m
 Das Bauteil `StandardMountAdapter` gehört zwar eigentlich zu den Halterungen,
 wird aber fest am Hauptgehäuse angebracht und bildet eine Hälfte des
 Befestigungsmechanismus. Es gehört also auch irgendwie zum Hauptgehäuse.
+
+Das Bauteil `AttachmentCover` verschließt die Öffnung des Standardgehäuses,
+an der nicht die Halteklammer montiert wird. Dieses Teil wird nicht benötigt,
+wenn das Gehäuse ohne zweite Öffnung verwendet wird.
 
 {{< imgproc "cura_maincase_parts" Resize 800x >}}
 Die Bauteile des Hauptgehäuses auf dem Druckbett

--- a/content/docs/hardware/general/collective-order/_index.de.md
+++ b/content/docs/hardware/general/collective-order/_index.de.md
@@ -22,7 +22,8 @@ Bitte beachte, dass sich das Projekt noch in der Entwicklung befindet, d.h.
 bestellst, speziell bei größeren Mengen, überprüfe bitte dass das zugrundeliegende
 Design und die Teileliste zusammenpassen. Und nicht das Eine neuer ist als
 das Andere. Wenn du mehrere Gehäuse drucken willst: Starte den Seriendruck
-erst, nachdem du ein Gerät fertig hast - so weißt du, dass alles passt.
+erst, nachdem du ein Gerät fertig gelötet und zusammengeschraubt hast - so 
+weißt du, dass alles passt.
 
 
 ## Ultraschallsensor-Boards

--- a/content/docs/hardware/general/collective-order/_index.de.md
+++ b/content/docs/hardware/general/collective-order/_index.de.md
@@ -21,7 +21,8 @@ Bitte beachte, dass sich das Projekt noch in der Entwicklung befindet, d.h.
 Änderungen in Hardware oder Design sind zu jeder Zeit möglich. Bevor du Teile
 bestellst, speziell bei größeren Mengen, überprüfe bitte dass das zugrundeliegende
 Design und die Teileliste zusammenpassen. Und nicht das Eine neuer ist als
-das Andere.
+das Andere. Wenn du mehrere Gehäuse drucken willst: Starte den Seriendruck
+erst, nachdem du ein Gerät fertig hast - so weißt du, dass alles passt.
 
 
 ## Ultraschallsensor-Boards

--- a/content/docs/hardware/general/collective-order/_index.en.md
+++ b/content/docs/hardware/general/collective-order/_index.en.md
@@ -14,7 +14,8 @@ Please note that the project is still in development, which means that changes
 in hardware or design are possible anytime. Before ordering parts, especially
 in large quantities, double check that the design you're working off of and the
 list of items you are about to purchase match, and that neither is out of date
-or ahead of the other.
+or ahead of the other. If you print several devices only start printing in series
+after assembling the first one - that way you know that everything fits.
 
 
 ## Ultrasonic Sensor Boards

--- a/content/docs/hardware/v00.03.12/build-instructions/_index.de.md
+++ b/content/docs/hardware/v00.03.12/build-instructions/_index.de.md
@@ -626,6 +626,10 @@ Folge dafür [der Anleitung für dein Betriebssystem]({{< relref "firmware" >}})
     daran hängen bleibt.
   - Mit 3 Stück M3x6 oder M3x8 in Unterseite verschrauben.
 * Displaykabel in Gehäuse einstecken.
+  - Falls du ein Gehäuse mit mehreren Montageöffnungen baust, entscheide dich, an
+    welcher Öffnung du die Halteklammer installieren willst. Diese Öffnung
+    führt auch das Kabel. Die andere Öffnung wird mit dem Deckel 
+    ``AttachmentCover`` verschlossen.
   - Das Kabel sollte außen um die Elektronik herumgeführt werden, *nicht*
     zwischen dem GPS- und SD-Karten-Modul hindurch. Im neuen Gehäuse sollte
     dort genug Platz sein.

--- a/content/docs/hardware/v00.03.12/parts/_index.de.md
+++ b/content/docs/hardware/v00.03.12/parts/_index.de.md
@@ -196,23 +196,23 @@ aliases:
   <td><a href="https://www.amazon.de/dp/B079KDYBZ8">Link</a></td>
 </tr>
 <tr>
-  <td>19</td>
-  <td>M3x8mm Zylinderschraube mit Innensechskant (DIN912)</td>
+  <td>26</td>
+  <td>M3x8mm Zylinderschraube mit Innensechskant (DIN912). (1x GPS, 8x für zwei Gehäuseöffnungen, 3x Platine, 5x Deckel, 3x Display, 6x 2 Gepäckträgerhalterungen), je nach Variante können weniger Schrauben reichen.</td>
   <td></td>
 </tr>
 <tr>
   <td>1</td>
-  <td>M3x30mm Zylinderschraube mit Innensechskant (DIN912)</td>
+  <td>M3x30mm Zylinderschraube mit Innensechskant (DIN912) (für den Locking Pin)</td>
   <td></td>
 </tr>
 <tr>
-  <td>6</td>
-  <td>M3 Mutter (DIN934)</td>
+  <td>8</td>
+  <td>M3 Mutter (DIN934) (je 4x für zwei Gehäuseöffnungen, je nach Variante können weniger Muttern reichen.)</td>
   <td></td>
 </tr>
 <tr>
-  <td>13</td>
-  <td>Gewindeeinsatz / Einpressmutter M3x5.7</td>
+  <td>18</td>
+  <td>Gewindeeinsatz / Einpressmutter M3x5.7 - (1x GPS, 5x Deckel, 3x Platine, 3x Display, 6x für 2 Gepäckträgerhalterungen, je nach Variante können weniger Muttern reichen.)</td>
   <td><a href="https://www.amazon.de/dp/B08BCRZZS3">Link1</a> <a href="https://turmberg3d.de/products/gewindeeinsatze-fur-kunststoffteile?variant=39376894066883">Link2</a></td>
 </tr>
 


### PR DESCRIPTION
We had an issue with the MainCase not fitting the board recently, but also in the past people had problems with wrongly-sized displays that only became apparent after printing the 20 displaycases. To avoid this in the future generously sprinkle advice to "first assemble one device before printing bunches of devices".

Adapt the part numbers so enough screws for all mounting options are part of the default list. Explicitly list what screws are needed for to allow people to skip screws they don't need.