### PR TITLE
Small updates to links (remove unclear links)

### DIFF
--- a/content/docs/hardware/v00.03.10/parts/_index.de.md
+++ b/content/docs/hardware/v00.03.10/parts/_index.de.md
@@ -8,6 +8,7 @@ aliases:
 
 {{% pageinfo color="warning" %}}
 Diese Version des PCB ist veraltet. Neue Bestellungen sollten mit der aktuellsten Version durchgeführt werden.
+Insbesondere die Bestelllinks hier werden nicht mehr gepflegt.
 {{% /pageinfo %}}
 
 {{< include-markdown-partial "parts-notes.md" >}}

--- a/content/docs/hardware/v00.03.12/parts/_index.de.md
+++ b/content/docs/hardware/v00.03.12/parts/_index.de.md
@@ -64,7 +64,7 @@ aliases:
 <tr>
   <td>2</td>
   <td>JSN-SR04T Sensormodule (Hinweis beachten)</td>
-  <td><a href="https://de.aliexpress.com/item/4000057298353.html">JSN-SR04T-v3.0</a> <a href="https://de.aliexpress.com/item/4000089886629.html">AJ-SR04M-Link1</a> <a href="https://de.aliexpress.com/item/32898663512.html">AJ-SR04M-Link2</a></td>
+  <td><a href="https://de.aliexpress.com/item/4000057298353.html">JSN-SR04T-v3.0</a> <!--<a href="https://de.aliexpress.com/item/4000089886629.html">AJ-SR04M-Link1</a> <a href="https://de.aliexpress.com/item/32898663512.html">AJ-SR04M-Link2</a></td>-->
 </tr>
 
 <tr><th colspan="3">Kleinteile</th></tr>


### PR DESCRIPTION
Remove links to aj-sr04m after unsuccessful orders and only leave AJ-SR04T-v3.0 as discussed on monday.
Also add reminder that links on deprecated order page are not maintained.
