### PR TITLE
GitHub actions update

### DIFF
--- a/.github/workflows/gh-pages-production.yml
+++ b/.github/workflows/gh-pages-production.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '18.x'
 
       - name: Cache dependencies
         uses: actions/cache@v3

--- a/.github/workflows/gh-pages-production.yml
+++ b/.github/workflows/gh-pages-production.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/gh-pages-production.yml
+++ b/.github/workflows/gh-pages-production.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.85.0'
+          hugo-version: '0.107.0'
           extended: true
 
       - name: Setup Node

--- a/.github/workflows/gh-pages-production.yml
+++ b/.github/workflows/gh-pages-production.yml
@@ -9,7 +9,7 @@ jobs:
   deploy:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
@@ -26,7 +26,7 @@ jobs:
           node-version: '12.x'
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/gh-pages-staging.yml
+++ b/.github/workflows/gh-pages-staging.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '18.x'
 
       - name: Cache dependencies
         uses: actions/cache@v3

--- a/.github/workflows/gh-pages-staging.yml
+++ b/.github/workflows/gh-pages-staging.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/gh-pages-staging.yml
+++ b/.github/workflows/gh-pages-staging.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.85.0'
+          hugo-version: '0.107.0'
           extended: true
 
       - name: Setup Node

--- a/.github/workflows/gh-pages-staging.yml
+++ b/.github/workflows/gh-pages-staging.yml
@@ -9,7 +9,7 @@ jobs:
   deploy:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
@@ -26,7 +26,7 @@ jobs:
           node-version: '12.x'
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,5 +1,5 @@
-{{ if .Path }}
-  {{ $pathFormatted := replace .Path "\\" "/" }}
+{{ if .File }}
+  {{ $pathFormatted := replace .File.Path "\\" "/" }}
   {{ $gh_repo := ($.Param "github_repo") }}
   {{ $gh_subdir := ($.Param "github_subdir") }}
   {{ $gh_project_repo := ($.Param "github_project_repo") }}


### PR DESCRIPTION
The GitHub actions workflows showed some deprecation warnings (e.g. [staging flow](https://github.com/openbikesensor/openbikesensor.github.io/actions/runs/4036961672)).

With this PR the following components are updated / amended
- used GitHub actions - recent release version
- GitHub actions runner - Ubuntu latest
- Hugo version - 0.107.0 extended
- Node version - 18.x
- a layout file for changed Hugo syntax