### PR TITLE
Update GitHub action `setup-node` to version 3.

### DIFF
--- a/.github/workflows/gh-pages-production.yml
+++ b/.github/workflows/gh-pages-production.yml
@@ -21,7 +21,7 @@ jobs:
           extended: true
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '18.x'
 

--- a/.github/workflows/gh-pages-staging.yml
+++ b/.github/workflows/gh-pages-staging.yml
@@ -21,7 +21,7 @@ jobs:
           extended: true
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '18.x'
 


### PR DESCRIPTION
After publishing the webpage the following warning was shown on the actions summary.

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-node@v1.
For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```