### PR TITLE
Generates the webpage for host www.openbikesensor.org.

### DIFF
--- a/.github/workflows/gh-pages-production.yml
+++ b/.github/workflows/gh-pages-production.yml
@@ -36,7 +36,7 @@ jobs:
       - run: npm ci
 
       - name: Build
-        run: hugo --minify -b "https://openbikesensor.org"
+        run: hugo --minify -b "https://www.openbikesensor.org"
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Solves the issue with references which would point otherwise to host openbikesensor.org.

fixes #179