### PR TITLE
Consistency in calling the device tty.usbserial-0001

### DIFF
--- a/content/docs/firmware/flash-macos.de.md
+++ b/content/docs/firmware/flash-macos.de.md
@@ -33,7 +33,7 @@ Führe **im selben Verzeichnis**, in das du die ZIP-Datei entpackt hast, folgend
 ```bash
 esptool.py \
     --chip esp32 \
-    --port /dev/ttyUSB0 \
+    --port /dev/tty.usbserial-0001 \
     --baud 921600 \
     --before default_reset \
     --after hard_reset \
@@ -54,7 +54,7 @@ Wenn du keine Schreibberechtigung hast, kannst du den Dateimodus des Geräts
 ändern (oder das Kommando als root ausführen):
 
 ```bash
-sudo chmod 0x777 /dev/ttyUSB0
+sudo chmod 0x777 /dev/tty.usbserial-0001
 ```
 
 Sollte alles fehlschlagen, und du noch Fragen haben oder weitere Infos suchen, findest


### PR DESCRIPTION
Replace `ttyUSB0` by `tty.usbserial-0001` as the page mentions ...

> Stelle sicher, dass du den Gerätenamen für das USB-Gerät kennst. Dies ist
> normalerweise `/dev/tty.usbserial-0001` -- dies wird auch im Beispiel unten
> angenommen.

... which may confuse some people.