### PR TITLE
add info about keeping versions consistent.

### DIFF
--- a/content/docs/hardware/general/case/parts.de.md
+++ b/content/docs/hardware/general/case/parts.de.md
@@ -14,6 +14,12 @@ Github in der neuesten Version als ZIP-Archiv. Darin finden sich im Ordner
 <a class="btn btn-primary btn-lg" href="https://github.com/openbikesensor/OpenBikeSensor3dPrintableCase/archive/refs/heads/main.zip">Alles herunterladen<a>
 </div>
 
+{{% alert title="Achtung: Kompatibilität zwischen Versionen" color="warning" %}}
+Wir halten die Teile zu Halterungen älterer Versionen kompatibel. Aber Teile für ein Geräteelement (z.B. Gehäuse und Deckel, Display und Deckel, die verschiedenen 
+Elemente der Sattelhalterung) können sich zwischen Versionen verändern. Wenn du ein einzelnes Gehäuseteil (z.B. Deckel mit Logo) bekommst, prüfe genau im Slicer, ob
+es zu deinen Gehäusedateien passt. Wenn du z.B. ein ``MainCaseLid`` mit Logo weitergeben möchtest, gib ihn am besten im Bundle mit ``MainCase`` weiter. 
+{{% /alert %}}
+
 Eine detaillierte Anleitung zum Gehäusedruck gibt es [hier]({{< relref "." >}}).
 
 ### Hauptgehäuse

--- a/content/docs/hardware/general/case/printing/_index.de.md
+++ b/content/docs/hardware/general/case/printing/_index.de.md
@@ -94,6 +94,13 @@ heruntergeladen werden:
 Im Archiv befindet sich ein Ordner `export/` mit den obigen Kategorien, und
 darin sind jeweils die STL-Dateien für den Slicer zu finden.
 
+{{% alert title="Achtung: Kompatibilität zwischen Versionen" color="warning" %}}
+Wir halten die Teile zu Halterungen älterer Versionen kompatibel. Aber Teile für ein Geräteelement (z.B. Hauptgehäuse und Deckel, Display und Deckel, die verschiedenen 
+Elemente der Sattelhalterung) können sich zwischen Versionen verändern. Wenn du ein einzelnes Gehäuseteil (z.B. Deckel mit Logo) als ``.stl`` bekommst, prüfe genau im Slicer, ob
+es zu deinen Gehäusedateien passt. Wenn du z.B. ein ``MainCaseLid`` mit Logo weitergeben möchtest, gib ihn am besten im Bundle mit ``MainCase`` weiter. 
+{{% /alert %}}
+
+
 ### Allgemeines Vorgehen
 
 Der Import einer STL-Datei in eine Slicer Software (wie z.B. Cura) ist der


### PR DESCRIPTION
Recently a bunch of people tried (print first test second) using rather old ``MainCaseLid`` versions (sometimes from spring/summer 2021). We should make explicit that these aren't necessarily combineable betewen versions.