### PR TITLE
fix sd card link (reichelt sd still exist but not OBS compatible anym…

### DIFF
--- a/content/docs/hardware/v00.03.12/parts/_index.de.md
+++ b/content/docs/hardware/v00.03.12/parts/_index.de.md
@@ -78,7 +78,7 @@ Bei manchen Komponenten funktionieren die Links auf die Produkte nicht mehr. Wir
   <td>1</td>
   <td>SD-Karte, 16 GB / 32 GB (Hinweis beachten)</td>
   <td>
-    <a href="https://www.reichelt.de/microsdhc-speicherkarte-32gb-sandisk-ultra-sdsqua4032ggn6ma-p297179.html">reichelt.de</a>
+    <a href="https://www.amazon.de/gp/product/B008RDCC26/ref=ox_sc_saved_image_6?smid=A3JWKAKR8XB7XF&psc=1">amazon.de</a>
     <br/>
     <a href="https://www.google.com/search?q=sandisk+ultra+16gb&tbm=shop">google Suche</a> 
   </td>

--- a/layouts/partials/parts-notes.md
+++ b/layouts/partials/parts-notes.md
@@ -21,7 +21,9 @@ geliefert werden und einige Wochen Lieferzeit haben, solltest du alles doppelt
   Bezeichnung "ESP32 DEVKIT v1" verkauft.
 
 * **SD-Karte**: Billige SD-Karten haben schon öfters Probleme verursacht, wähle
-  lieber ein Markenprodukt.
+  lieber ein Markenprodukt. Versuche eine SD-Karte unter 100 MB/s zu bekommen,
+  z.B. SanDisk Karten mit 120 MB/s haben auch schon Probleme verursacht, da sie
+  die von uns verwendete Schnittstelle nicht mehr unterstützen.
 
 * **GPS-Modul**: Bevorzuge die Variante mit großer Antenne
   ([Link1](https://de.aliexpress.com/item/1550843440.html),


### PR DESCRIPTION
As discussed in the meeting: During OBS Hessen workshop we found the Reichelt SD card to be non-compatible with OBS. This link is from the [respective forum thread](https://forum.openbikesensor.org/t/reichelt-teileliste/1333/5?u=gluap).